### PR TITLE
Use arena-allocation for memory handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
-obj/
+*.so
+*.a
+.obj/
 bin/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "arena-allocator"]
+	path = arena-allocator
+	url = https://github.com/olemorud/arena-allocator.git

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,18 @@ COMPILER ?= gcc
 CC := gcc
 
 # -fsanitize={address,undefined}
-CFLAGS.gcc.debug := -Og -ggdb -fanalyzer -DBACKTRACE -rdynamic -fsanitize=address -fno-omit-frame-pointer
+CFLAGS.gcc.debug := -Og -ggdb -DBACKTRACE -rdynamic -fanalyzer -fsanitize=address -fno-omit-frame-pointer
 CFLAGS.gcc.release := -O3 -g -march=native -DNDEBUG
-CFLAGS.gcc := ${CFLAGS.gcc.${BUILD}} -Iinclude -Wall -Wextra -Wpedantic -Werror -Wno-strict-aliasing -fstack-protector-all -std=gnu11
+CFLAGS.gcc := ${CFLAGS.gcc.${BUILD}} -fstack-protector-all -std=gnu11 #-Wpedantic
 
 CFLAGS.clang.debug=-O0 -g3 -DBACKTRACE -rdynamic
 CFLAGS.clang.release=-O3 -g -march=native -DNDEBUG
-CFLAGS.clang=-Iinclude -Wall -Wextra -Wpedantic -Werror -Wno-strict-aliasing -fstack-protector-all ${CFLAGS.clang.${BUILD}}
+CFLAGS.clang=-Iinclude -Wno-strict-aliasing -fstack-protector-all ${CFLAGS.clang.${BUILD}}
 
-CFLAGS := ${CFLAGS.${COMPILER}}
+CFLAGS := ${CFLAGS.${COMPILER}} \
+		  -Iinclude -Iarena-allocator/include \
+		  -std=c2x \
+		  -Wall -Wextra -Wpedantic -Werror
 
 LD_PRELOAD:=
 
@@ -27,17 +30,23 @@ LD_PRELOAD:=
 BUILD_DIR := bin/${BUILD}
 
 OBJ_DIR := .obj/${BUILD}
-_OBJS := main.o parse.o json_value.o util.o
+_OBJS := main.o parse.o json_value.o util.o libarena.a
 OBJS := $(patsubst %,$(OBJ_DIR)/%,$(_OBJS))
-
 
 all : $(BUILD_DIR)/parse
 
-$(BUILD_DIR)/parse : $(OBJS) | $(BUILD_DIR) Makefile
+$(BUILD_DIR)/parse : $(OBJS) $(OBJ_DIR)/libarena.a | $(BUILD_DIR) Makefile
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
-$(OBJ_DIR)/main.o : src/main.c | $(OBJ_DIR) Makefile
+$(OBJ_DIR)/main.o : src/main.c arena-allocator | $(OBJ_DIR) Makefile
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) -c $< -o $@
+
+$(OBJ_DIR)/libarena.a : arena-allocator .gitmodules $(wildcard .git/modules/arena-allocator/HEAD) | $(OBJ_DIR) Makefile
+	(cd arena-allocator && make static)
+	cp --force arena-allocator/lib/libarena.a $(OBJ_DIR)/libarena.a
+
+arena-allocator : .gitmodules
+	git submodule update $@
 
 $(OBJ_DIR)/%.o : src/%.c include/%.h | $(OBJ_DIR) Makefile
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) -c $< -o $@

--- a/README.md
+++ b/README.md
@@ -7,21 +7,20 @@ Not guaranteed to be safe, reliable or efficient.
 ## Usage
 
 ###  Compile
+
 build (release build):
+
 ```sh
 make BUILD=release
 ```
+
 To make a debug build just run `make`.
 
 ### Run
 
 ```sh
-./bin/{release|debug}/json_parser sample.json
+./bin/release/json_parser  sample-files/large-file.json
 ```
-
-## Limitations
-
-Does not support unicode.
 
 ## Implementation
 
@@ -38,19 +37,28 @@ struct json_value {
         struct json_value** array;
         char*               string;
         bool                boolean;
-        int64_t             number;
+        double              number;
     };
 };
 ```
 
 ### Types
 
+#### JSON Objects
+
+Object values have the type field set to `(enum json_type) object`
+
+They are stored using a poorly written map implementation with the type `obj_t`
+in `json_value.object`
+
+See [obj_t](#obj_t) for more details.
+
 #### JSON Arrays
 
 Array values have the type field set to `(enum json_type) array`
 
 JSON Arrays are stored as null-terminated `json_value*` arrays,
-`struct json_value**`, in `json_value.array`
+i.e. `struct json_value**`, in `json_value.array`
 
 
 #### JSON Numbers
@@ -82,15 +90,9 @@ The values are stored as `bool` in `json_value.boolean`
 Null values have type field set to `(enum json_type) null`.
 
 
-#### JSON Objects
+### obj\_t
 
-Object values have the type field set to `(enum json_type) object`
-
-They are stored using a poorly written map implementation with the type `obj_t`
-in `json_value.object`
-
-##### obj\_t
-
+`obj_t` is defined in `json_value.h` as:
 ```c
 typedef struct obj_entry {
     char const* key;
@@ -101,7 +103,7 @@ typedef struct obj_entry {
 typedef __p_obj_entry obj_t[OBJ_SIZE]; // OBJ_SIZE=1024
 ```
 
-##### obj\_t methods
+#### obj\_t methods
 
 `void* obj_at(obj_t m, char* key)`
 
@@ -113,5 +115,5 @@ Insert a key-value pair
 
 `void obj_delete(obj_t m)`
 
-Free memory allocated for object
+Recursively free memory allocated for object and children objects.
 

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,4 +1,5 @@
 -Iinclude
+-Iarena-allocator/include
 -Wall
 -Werror
 -Wpedantic

--- a/include/json_value.h
+++ b/include/json_value.h
@@ -2,6 +2,7 @@
 #ifndef _JSON_VALUE_H
 #define _JSON_VALUE_H
 
+#include "arena.h"
 #include "config.h"
 #include <stdbool.h> // bool
 
@@ -9,7 +10,7 @@ typedef struct obj_entry {
     char const* key;
     struct json_value* val;
     struct obj_entry* next;
-} * __p_obj_entry;
+}* __p_obj_entry;
 
 typedef __p_obj_entry obj_t[OBJ_SIZE];
 
@@ -32,11 +33,11 @@ struct json_value {
 };
 
 void* obj_at(obj_t m, char* const key);
-bool obj_insert(obj_t m, char* const key, struct json_value* value);
-void obj_delete(obj_t* m);
+bool obj_insert(obj_t m, char* const key, struct json_value* value, arena_t* arena);
+void obj_delete(obj_t* m, arena_t* arena);
 
 void print_json(struct json_value val, int indent);
 
-void json_value_delete(struct json_value val);
+void json_value_delete(struct json_value val, arena_t* arena);
 
 #endif

--- a/include/parse.h
+++ b/include/parse.h
@@ -4,8 +4,9 @@
 
 #include "json_value.h"
 
+#include "arena.h"
 #include <stdio.h> // FILE*
 
-struct json_value parse_json_value(FILE* fp);
+struct json_value parse_json_value(FILE* fp, arena_t* arena);
 
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -10,6 +10,6 @@ __attribute__((__noreturn__)) void err_ctx(int exit_code, FILE* fp, const char* 
 void* malloc_or_die(size_t size);
 void* realloc_or_die(void* ptr, size_t size);
 void* calloc_or_die(size_t nmemb, size_t size);
-void print_trace();
+void print_trace(void);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,8 @@
 
 int main(int argc, char* argv[])
 {
+    arena_t arena_default = arena_new();
+
     if (argc != 2) {
         errx(EXIT_FAILURE, "Usage: %s <file>", argv[0]);
     }
@@ -34,13 +36,13 @@ int main(int argc, char* argv[])
 
     FILE* fp = fopen(argv[1], "r");
 
-    struct json_value x = parse_json_value(fp);
+    struct json_value x = parse_json_value(fp, &arena_default);
 
     print_json(x, 1);
 
-    json_value_delete(x);
-
     fclose(fp);
+
+    arena_delete(&arena_default);
 
     return EXIT_SUCCESS;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -42,13 +42,12 @@ void* realloc_or_die(void* ptr, size_t size)
 {
     void* tmp = realloc(ptr, size);
 
-    if (ptr == NULL) {
+    if (tmp == NULL) {
         if (errno != 0) {
-            free(ptr);
             err(errno, "realloc_or_die failed");
         }
 
-        fprintf(stderr, "\nrealloc_or_die returned NULL but errno is 0, ptr: %p size: %zu\n", ptr, size);
+        fprintf(stderr, "\nrealloc_or_die returned NULL but errno is 0, ptr: %p size: %zu\n", tmp, size);
         exit(EXIT_FAILURE);
     }
 
@@ -67,9 +66,11 @@ void* calloc_or_die(size_t nmemb, size_t size)
 
 // from the glibc man pages
 // https://www.gnu.org/software/libc/manual/html_node/Backtraces.html
-void print_trace()
+void print_trace(void)
 {
-#ifdef BACKTRACE
+#ifndef BACKTRACE
+    return;
+#else
     void* array[500];
     char** strings;
     int size, i;
@@ -79,8 +80,9 @@ void print_trace()
 
     if (strings != NULL) {
         printf("\n\n=== Obtained %d stack frames. === \n", size);
-        for (i = 0; i < size; i++)
+        for (i = 0; i < size; i++) {
             printf("%s\n", strings[i]);
+        }
     }
 
     free(strings);


### PR DESCRIPTION
Arena allocation make deallocation of nested structed MUCH faster, and
improves the spatial locality of allocations. It makes no sense to
deallocate only parts of a JSON structure so arenas are a good fit here.